### PR TITLE
Update matplotlib.hist properties

### DIFF
--- a/volatility/volest.py
+++ b/volatility/volest.py
@@ -526,7 +526,7 @@ class VolatilityEstimator(object):
 
         fig = plt.figure(figsize=(8, 6))
         
-        n, bins, patches = plt.hist(estimator, bins, normed=normed, facecolor='blue', alpha=0.25)
+        n, bins, patches = plt.hist(estimator, bins, color='blue', density=True, stacked=True, cumulative=True)
         
         if normed:
             y = norm.pdf(bins, mean, std)


### PR DESCRIPTION
https://github.com/jasonstrimpel/volatility-trading/issues/21

`plt.hist` is changed. `normed` is not supported anymore. 

However, I don't find a way to add a color to the historgram. 

The new result looks like this

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/750998/154695655-ef25eb58-d0ff-45c9-9812-b46bed2feb5f.png">



