### PR TITLE
Update export pdf file from notebook

### DIFF
--- a/volatility/volest.py
+++ b/volatility/volest.py
@@ -717,7 +717,9 @@ class VolatilityEstimator(object):
         benchmark_regression = self.benchmark_regression(window=window)
         
         filename = self._symbol.upper() + '_termsheet_' + datetime.datetime.today().strftime("%Y%m%d") + '.pdf'
-        fn = os.path.abspath(os.path.join(u'..', u'term-sheets', filename))
+        script_dir = os.path.abspath('')
+        rel_path = "term-sheets/{}".format(filename)
+        fn = os.path.join(script_dir, rel_path)
         pp = PdfPages(fn)
         
         pp.savefig(cones_fig)


### PR DESCRIPTION
When I run it from my notebook, I get an error message because it tries to write the term sheet to a subdirectory that doesn't exist.

It becomes problematic if we assume that you first install the package, import it, and then run it. 

But the installation doesn't work for me, so I just use it from the notebook.